### PR TITLE
build: verify checksum of `rustup-init.sh`

### DIFF
--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2020-11-09 -y
-export PATH="$HOME/.cargo/bin:$PATH"
+RUST_TOOLCHAIN=$(cat rust-toolchain)
+# We specify a particular rustup version and a SHA256 hash for
+# `rustup-init.sh`, computed ourselves and hardcoded here.
+RUSTUP_LATEST_VERSION=1.24.3
+OUR_RUSTUP_INIT_SHA="a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8"
+
+curl --proto '=https' --tlsv1.2 -sSf -O \
+  https://raw.githubusercontent.com/rust-lang/rustup/${RUSTUP_LATEST_VERSION}/rustup-init.sh
+# Verify checksum of rustup script.
+echo "${OUR_RUSTUP_INIT_SHA} rustup-init.sh" | sha256sum --check -
+# Run rustup.
+sh rustup-init.sh --default-toolchain ${RUST_TOOLCHAIN} -y
+export PATH="${HOME}/.cargo/bin:${PATH}"
+
 
 cd /io
 


### PR DESCRIPTION
Adds a verification process for the rustup script, so that we're not curl-piping-to-bash.

This adds a small cost going forward: when updating rustup, we'll need to review the changes to https://github.com/rust-lang/rustup/blob/master/rustup-init.sh and recompute the SHA256 hash.